### PR TITLE
Pre-checks for operations on accessors and resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "hal",
     "hateoas"
   ],
+  "homepage": "https://granito-source.github.io/ngx-hal-client/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/granito-source/ngx-hal-client.git"

--- a/src/lib/accessor.spec.ts
+++ b/src/lib/accessor.spec.ts
@@ -26,6 +26,75 @@ describe('Accessor', () => {
         expect(accessor.self).toBe('/api/root');
     });
 
+    describe('#canCreate', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canCreate).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'GET'
+                    }
+                }
+            });
+
+            expect(notArray.canCreate).toBe(true);
+        });
+
+        it('is false when no POST in methods array', () => {
+            const noPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canCreate).toBe(false);
+        });
+
+        it('is true when POST is in methods array', () => {
+            const withPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'POST', 'PUT']
+                    }
+                }
+            });
+
+            expect(withPost.canCreate).toBe(true);
+        });
+
+        it('is true when POST matches case insensitively', () => {
+            const withPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'PoSt']
+                    }
+                }
+            });
+
+            expect(withPost.canCreate).toBe(true);
+        });
+    });
+
     describe('#create()', () => {
         const item = new TestResource({ version: '3.5.7' });
 

--- a/src/lib/accessor.spec.ts
+++ b/src/lib/accessor.spec.ts
@@ -287,6 +287,75 @@ describe('Accessor', () => {
         });
     });
 
+    describe('#canRead', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canRead).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'POST'
+                    }
+                }
+            });
+
+            expect(notArray.canRead).toBe(true);
+        });
+
+        it('is false when no GET in methods array', () => {
+            const noPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['POST']
+                    }
+                }
+            });
+
+            expect(noPost.canRead).toBe(false);
+        });
+
+        it('is true when GET is in methods array', () => {
+            const withPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['PUT', 'GET', 'DELETE']
+                    }
+                }
+            });
+
+            expect(withPost.canRead).toBe(true);
+        });
+
+        it('is true when GET matches case insensitively', () => {
+            const withPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'GeT']
+                    }
+                }
+            });
+
+            expect(withPost.canRead).toBe(true);
+        });
+    });
+
     describe('#read()', () => {
         it('emits resource at self link', () => {
             let next!: TestResource;
@@ -469,7 +538,7 @@ describe('Accessor', () => {
             expect(notArray.canDelete).toBe(true);
         });
 
-        it('is false when no POST in methods array', () => {
+        it('is false when no DELETE in methods array', () => {
             const noPost = new Accessor({
                 _client: spectator.httpClient,
                 _links: {

--- a/src/lib/accessor.spec.ts
+++ b/src/lib/accessor.spec.ts
@@ -443,6 +443,75 @@ describe('Accessor', () => {
         });
     });
 
+    describe('#canDelete', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canDelete).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'GET'
+                    }
+                }
+            });
+
+            expect(notArray.canDelete).toBe(true);
+        });
+
+        it('is false when no POST in methods array', () => {
+            const noPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canDelete).toBe(false);
+        });
+
+        it('is true when DELETE is in methods array', () => {
+            const withPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'DELETE', 'PUT']
+                    }
+                }
+            });
+
+            expect(withPost.canDelete).toBe(true);
+        });
+
+        it('is true when DELETE matches case insensitively', () => {
+            const withPost = new Accessor({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'DeLeTe']
+                    }
+                }
+            });
+
+            expect(withPost.canDelete).toBe(true);
+        });
+    });
+
     describe('#delete()', () => {
         it('deletes resource at self link', () => {
             let next = false;

--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -129,6 +129,75 @@ describe('Collection', () => {
         });
     });
 
+    describe('#canCreate', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canCreate).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'GET'
+                    }
+                }
+            });
+
+            expect(notArray.canCreate).toBe(true);
+        });
+
+        it('is false when no POST in methods array', () => {
+            const noPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canCreate).toBe(false);
+        });
+
+        it('is true when POST is in methods array', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'POST', 'PUT']
+                    }
+                }
+            });
+
+            expect(withPost.canCreate).toBe(true);
+        });
+
+        it('is true when POST matches case insensitively', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'PoSt']
+                    }
+                }
+            });
+
+            expect(withPost.canCreate).toBe(true);
+        });
+    });
+
     describe('#create()', () => {
         const item = new TestResource({ version: '3.5.7' });
 

--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -651,6 +651,75 @@ describe('Collection', () => {
         });
     });
 
+    describe('#canDelete', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canDelete).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'GET'
+                    }
+                }
+            });
+
+            expect(notArray.canDelete).toBe(true);
+        });
+
+        it('is false when no POST in methods array', () => {
+            const noPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canDelete).toBe(false);
+        });
+
+        it('is true when DELETE is in methods array', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'DELETE', 'PUT']
+                    }
+                }
+            });
+
+            expect(withPost.canDelete).toBe(true);
+        });
+
+        it('is true when DELETE matches case insensitively', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'DeLeTe']
+                    }
+                }
+            });
+
+            expect(withPost.canDelete).toBe(true);
+        });
+    });
+
     describe('#delete()', () => {
         it('deletes resource at self link when it exists', () => {
             let next = false;

--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -424,6 +424,75 @@ describe('Collection', () => {
         });
     });
 
+    describe('#canRead', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canRead).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'POST'
+                    }
+                }
+            });
+
+            expect(notArray.canRead).toBe(true);
+        });
+
+        it('is false when no GET in methods array', () => {
+            const noPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['POST']
+                    }
+                }
+            });
+
+            expect(noPost.canRead).toBe(false);
+        });
+
+        it('is true when GET is in methods array', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['PUT', 'GET', 'DELETE']
+                    }
+                }
+            });
+
+            expect(withPost.canRead).toBe(true);
+        });
+
+        it('is true when GET matches case insensitively', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'GeT']
+                    }
+                }
+            });
+
+            expect(withPost.canRead).toBe(true);
+        });
+    });
+
     describe('#read()', () => {
         it('emits collection at self link when it exists', () => {
             let next: Collection<TestResource> | undefined;
@@ -677,7 +746,7 @@ describe('Collection', () => {
             expect(notArray.canDelete).toBe(true);
         });
 
-        it('is false when no POST in methods array', () => {
+        it('is false when no DELETE in methods array', () => {
             const noPost = new Collection(TestResource, {
                 _client: spectator.httpClient,
                 _links: {

--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -26,6 +26,7 @@ describe('Collection', () => {
                 self: { href: '/api/test' },
                 find: {
                     href: '/api/search{?q}',
+                    methods: ['GET'],
                     templated: true
                 },
                 notmpl: {
@@ -126,6 +127,14 @@ describe('Collection', () => {
 
             expect(accessor).toBeDefined();
             expect(accessor?.self).toBe('/api/search{?q}');
+        });
+
+        it('preserves methods array when present', () => {
+            const accessor = collection.follow('find');
+
+            expect(accessor?.canCreate).toBe(false);
+            expect(accessor?.canRead).toBe(true);
+            expect(accessor?.canDelete).toBe(false);
         });
     });
 

--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -617,6 +617,75 @@ describe('Collection', () => {
         });
     });
 
+    describe('#canUpdate', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canUpdate).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'PUT'
+                    }
+                }
+            });
+
+            expect(notArray.canUpdate).toBe(true);
+        });
+
+        it('is false when no PUT in methods array', () => {
+            const noPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canUpdate).toBe(false);
+        });
+
+        it('is true when PUT is in methods array', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'PUT', 'DELETE']
+                    }
+                }
+            });
+
+            expect(withPost.canUpdate).toBe(true);
+        });
+
+        it('is true when PUT matches case insensitively', () => {
+            const withPost = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'pUt']
+                    }
+                }
+            });
+
+            expect(withPost.canUpdate).toBe(true);
+        });
+    });
+
     describe('#update()', () => {
         it('puts payload to self when it exists', () => {
             let next: Accessor | undefined;

--- a/src/lib/hal-base.ts
+++ b/src/lib/hal-base.ts
@@ -11,6 +11,8 @@ interface Link {
     href: string;
 
     templated?: boolean;
+
+    methods?: any;
 }
 
 /**
@@ -28,6 +30,16 @@ export abstract class HalBase {
      */
     get self(): string {
         return this._links[self]?.href;
+    }
+
+    get canCreate(): boolean {
+        const methods = this._links[self]?.methods;
+
+        if (!Array.isArray(methods))
+            return true;
+
+        return !!methods.find(method => typeof method === 'string' &&
+            method.toUpperCase() === 'POST');
     }
 
     /**

--- a/src/lib/hal-base.ts
+++ b/src/lib/hal-base.ts
@@ -33,17 +33,27 @@ export abstract class HalBase {
     }
 
     /**
-     * This property is true when either `methods` array does not exist
+     * This property is `true` when either `methods` array does not exist
      * in the `self` link or the array exists and contains `POST` string.
+     * It is `false` otherwise.
      */
     get canCreate(): boolean {
         return this.can('POST');
     }
 
     /**
-     * This property is true when either `methods` array does not exist
+     * This property is `true` when either `methods` array does not exist
+     * in the `self` link or the array exists and contains `GET` string.
+     * It is `false` otherwise.
+     */
+    get canRead(): boolean {
+        return this.can('GET');
+    }
+
+    /**
+     * This property is `true` when either `methods` array does not exist
      * in the `self` link or the array exists and contains `DELETE`
-     * string.
+     * string. It is `false` otherwise.
      */
     get canDelete(): boolean {
         return this.can('DELETE');

--- a/src/lib/hal-base.ts
+++ b/src/lib/hal-base.ts
@@ -12,7 +12,7 @@ interface Link {
 
     templated?: boolean;
 
-    methods?: any;
+    methods?: string[];
 }
 
 /**
@@ -113,8 +113,15 @@ export abstract class HalBase {
         return func(self);
     }
 
-    protected accessor(href: string): Accessor {
-        return this.instanceOf(Accessor, { _links: { self: { href } } });
+    protected accessor(href: string, methods?: string[]): Accessor {
+        return this.instanceOf(Accessor, {
+            _links: {
+                self: {
+                    href,
+                    methods
+                }
+            }
+        });
     }
 
     protected instanceOf<T>(type: Type<T>, obj: Object): T {

--- a/src/lib/hal-base.ts
+++ b/src/lib/hal-base.ts
@@ -159,7 +159,7 @@ export abstract class HalBase {
         }));
     }
 
-    private can(method: string): boolean {
+    protected can(method: string): boolean {
         const methods = this._links[self]?.methods;
 
         if (!Array.isArray(methods))

--- a/src/lib/hal-base.ts
+++ b/src/lib/hal-base.ts
@@ -34,16 +34,19 @@ export abstract class HalBase {
 
     /**
      * This property is true when either `methods` array does not exist
-     * in the `self` link or the array exists and contains `POST` method.
+     * in the `self` link or the array exists and contains `POST` string.
      */
     get canCreate(): boolean {
-        const methods = this._links[self]?.methods;
+        return this.can('POST');
+    }
 
-        if (!Array.isArray(methods))
-            return true;
-
-        return !!methods.find(method => typeof method === 'string' &&
-            method.toUpperCase() === 'POST');
+    /**
+     * This property is true when either `methods` array does not exist
+     * in the `self` link or the array exists and contains `DELETE`
+     * string.
+     */
+    get canDelete(): boolean {
+        return this.can('DELETE');
     }
 
     /**
@@ -137,5 +140,15 @@ export abstract class HalBase {
             path: err.url,
             ...err.error
         }));
+    }
+
+    private can(method: string): boolean {
+        const methods = this._links[self]?.methods;
+
+        if (!Array.isArray(methods))
+            return true;
+
+        return !!methods.find(m => typeof m === 'string' &&
+            m.toUpperCase() === method);
     }
 }

--- a/src/lib/hal-base.ts
+++ b/src/lib/hal-base.ts
@@ -32,6 +32,10 @@ export abstract class HalBase {
         return this._links[self]?.href;
     }
 
+    /**
+     * This property is true when either `methods` array does not exist
+     * in the `self` link or the array exists and contains `POST` method.
+     */
     get canCreate(): boolean {
         const methods = this._links[self]?.methods;
 

--- a/src/lib/resource.spec.ts
+++ b/src/lib/resource.spec.ts
@@ -572,6 +572,75 @@ describe('Resource', () => {
         });
     });
 
+    describe('#canUpdate', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items/8' }
+                }
+            });
+
+            expect(noMethods.canUpdate).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items/8',
+                        methods: 'PUT'
+                    }
+                }
+            });
+
+            expect(notArray.canUpdate).toBe(true);
+        });
+
+        it('is false when no PUT in methods array', () => {
+            const noPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items/8',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canUpdate).toBe(false);
+        });
+
+        it('is true when PUT is in methods array', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items/8',
+                        methods: ['GET', 'PUT', 'DELETE']
+                    }
+                }
+            });
+
+            expect(withPost.canUpdate).toBe(true);
+        });
+
+        it('is true when PUT matches case insensitively', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items/8',
+                        methods: [null, 'pUt']
+                    }
+                }
+            });
+
+            expect(withPost.canUpdate).toBe(true);
+        });
+    });
+
     describe('#update()', () => {
         it('puts payload to self when it exists', () => {
             let next: Accessor | undefined;

--- a/src/lib/resource.spec.ts
+++ b/src/lib/resource.spec.ts
@@ -389,6 +389,75 @@ describe('Resource', () => {
         });
     });
 
+    describe('#canRead', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canRead).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'POST'
+                    }
+                }
+            });
+
+            expect(notArray.canRead).toBe(true);
+        });
+
+        it('is false when no GET in methods array', () => {
+            const noPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['POST']
+                    }
+                }
+            });
+
+            expect(noPost.canRead).toBe(false);
+        });
+
+        it('is true when GET is in methods array', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['PUT', 'GET', 'DELETE']
+                    }
+                }
+            });
+
+            expect(withPost.canRead).toBe(true);
+        });
+
+        it('is true when GET matches case insensitively', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'GeT']
+                    }
+                }
+            });
+
+            expect(withPost.canRead).toBe(true);
+        });
+    });
+
     describe('#read()', () => {
         it('emits resource at self link when it exists', () => {
             let next: TestResource | undefined;
@@ -629,7 +698,7 @@ describe('Resource', () => {
             expect(notArray.canDelete).toBe(true);
         });
 
-        it('is false when no POST in methods array', () => {
+        it('is false when no DELETE in methods array', () => {
             const noPost = new Resource({
                 _client: spectator.httpClient,
                 _links: {

--- a/src/lib/resource.spec.ts
+++ b/src/lib/resource.spec.ts
@@ -94,6 +94,75 @@ describe('Resource', () => {
         });
     });
 
+    describe('#canCreate', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canCreate).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'GET'
+                    }
+                }
+            });
+
+            expect(notArray.canCreate).toBe(true);
+        });
+
+        it('is false when no POST in methods array', () => {
+            const noPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canCreate).toBe(false);
+        });
+
+        it('is true when POST is in methods array', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'POST', 'PUT']
+                    }
+                }
+            });
+
+            expect(withPost.canCreate).toBe(true);
+        });
+
+        it('is true when POST matches case insensitively', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'PoSt']
+                    }
+                }
+            });
+
+            expect(withPost.canCreate).toBe(true);
+        });
+    });
+
     describe('#create()', () => {
         const item = new TestResource({ version: '3.5.7' });
 

--- a/src/lib/resource.spec.ts
+++ b/src/lib/resource.spec.ts
@@ -26,6 +26,7 @@ describe('Resource', () => {
                 self: { href: '/api/test' },
                 find: {
                     href: '/api/search{?q}',
+                    methods: ['GET', 'DELETE'],
                     templated: true
                 },
                 notmpl: {
@@ -91,6 +92,14 @@ describe('Resource', () => {
 
             expect(accessor).toBeDefined();
             expect(accessor?.self).toBe('/api/search{?q}');
+        });
+
+        it('preserves methods array when present', () => {
+            const accessor = resource.follow('find');
+
+            expect(accessor?.canCreate).toBe(false);
+            expect(accessor?.canRead).toBe(true);
+            expect(accessor?.canDelete).toBe(true);
         });
     });
 

--- a/src/lib/resource.spec.ts
+++ b/src/lib/resource.spec.ts
@@ -603,6 +603,75 @@ describe('Resource', () => {
         });
     });
 
+    describe('#canDelete', () => {
+        it('is true when no methods array', () => {
+            const noMethods = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/v1/items' }
+                }
+            });
+
+            expect(noMethods.canDelete).toBe(true);
+        });
+
+        it('is true when methods is not an array', () => {
+            const notArray = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: 'GET'
+                    }
+                }
+            });
+
+            expect(notArray.canDelete).toBe(true);
+        });
+
+        it('is false when no POST in methods array', () => {
+            const noPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET']
+                    }
+                }
+            });
+
+            expect(noPost.canDelete).toBe(false);
+        });
+
+        it('is true when DELETE is in methods array', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: ['GET', 'DELETE', 'PUT']
+                    }
+                }
+            });
+
+            expect(withPost.canDelete).toBe(true);
+        });
+
+        it('is true when DELETE matches case insensitively', () => {
+            const withPost = new Resource({
+                _client: spectator.httpClient,
+                _links: {
+                    self: {
+                        href: '/api/v1/items',
+                        methods: [null, 'DeLeTe']
+                    }
+                }
+            });
+
+            expect(withPost.canDelete).toBe(true);
+        });
+    });
+
     describe('#delete()', () => {
         it('deletes resource at self link when it exists', () => {
             let next = false;

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -31,7 +31,7 @@ export class Resource extends HalBase {
 
         return !uri ? undefined :
             this.accessor(!link.templated ? uri :
-                URI.parse(uri).expand(params));
+                URI.parse(uri).expand(params), link.methods);
     }
 
     /**

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -13,6 +13,10 @@ export type Params = Record<string, string | number | boolean>;
  * This class repesents an in-memory instance of a HAL resource.
  */
 export class Resource extends HalBase {
+    get canUpdate(): boolean {
+        return this.can('PUT');
+    }
+
     /**
      * Follow the relation link. Returns an accessor for the resource
      * or `undefined` if no such relation exists.


### PR DESCRIPTION
Implement pre-checks for operations on accessors and resources: `canCreate`, `canRead`, `canUpdate` and `canDelete`.