### PR TITLE
Implement pagination in `Collection`

### DIFF
--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -74,6 +74,57 @@ describe('Collection', () => {
         expect(collection.self).toBe('/api/test');
     });
 
+    describe('#start', () => {
+        it('is 0 by default', () => {
+            expect(collection.start).toBe(0);
+        });
+
+        it('is set by constructor if positive', () => {
+            const paged = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/test' }
+                },
+                _embedded: {
+                    values: []
+                },
+                start: 42
+            });
+
+            expect(paged.start).toBe(42);
+        });
+
+        it('is set to 0 if negative', () => {
+            const paged = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/test' }
+                },
+                _embedded: {
+                    values: []
+                },
+                start: -1
+            });
+
+            expect(paged.start).toBe(0);
+        });
+
+        it('is truncated if fractional', () => {
+            const paged = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/test' }
+                },
+                _embedded: {
+                    values: []
+                },
+                start: 42.9
+            });
+
+            expect(paged.start).toBe(42);
+        });
+    });
+
     describe('#values', () => {
         it('uses first embedded array', () => {
             const values = collection.values;

--- a/src/lib/collection.spec.ts
+++ b/src/lib/collection.spec.ts
@@ -215,6 +215,13 @@ describe('Collection', () => {
             expect(broken.next()).toBeUndefined();
         });
 
+        it('returns accessor with link when next rel exists', () => {
+            const accessor = paged.next();
+
+            expect(accessor).toBeDefined();
+            expect(accessor?.self).toBe('/api/test?start=44&limit2');
+        });
+
         it('returns undefined when canRead() is false', () => {
             const broken = new Collection(TestResource, {
                 _client: spectator.httpClient,
@@ -236,12 +243,56 @@ describe('Collection', () => {
 
             expect(broken.next()).toBeUndefined();
         });
+    });
 
-        it('returns accessor with link when next rel exists', () => {
-            const accessor = paged.next();
+    describe('#previous()', () => {
+        it('returns undefined when prev rel does not exist', () => {
+            expect(collection.previous()).toBeUndefined();
+        });
+
+        it('returns undefined when prev rel does not have href', () => {
+            const broken = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/test' },
+                    prev: {}
+                },
+                _embedded: {
+                    array: []
+                },
+                start: 0
+            });
+
+            expect(broken.previous()).toBeUndefined();
+        });
+
+        it('returns accessor with link when prev rel exists', () => {
+            const accessor = paged.previous();
 
             expect(accessor).toBeDefined();
-            expect(accessor?.self).toBe('/api/test?start=44&limit2');
+            expect(accessor?.self).toBe('/api/test?start=40&limit2');
+        });
+
+        it('returns undefined when canRead() is false', () => {
+            const broken = new Collection(TestResource, {
+                _client: spectator.httpClient,
+                _links: {
+                    self: { href: '/api/test' },
+                    prev: {
+                        href: '/api/test?start=40&limit2',
+                        methods: ['DELETE']
+                    }
+                },
+                _embedded: {
+                    array: [
+                        { version: '2.0.0' },
+                        { version: '3.0.0' }
+                    ]
+                },
+                start: 42
+            });
+
+            expect(broken.previous()).toBeUndefined();
         });
     });
 

--- a/src/lib/collection.ts
+++ b/src/lib/collection.ts
@@ -1,6 +1,9 @@
 import { Type } from '@angular/core';
 import { Observable, catchError, map } from 'rxjs';
 import { Resource } from './resource';
+import { Accessor } from './accessor';
+
+const next = 'next';
 
 /**
  * This class represents an in-memory collection of resources.
@@ -39,6 +42,12 @@ export class Collection<T extends Resource> extends Resource {
         this.values = [];
     }
 
+    next(): Accessor | undefined {
+        const accessor = this.follow(next);
+
+        return !!accessor && accessor.canRead ? accessor : undefined;
+    }
+
     /**
      * Refresh the resource collection. In other words, read
      * the resource collection identified by `self` link.
@@ -46,12 +55,12 @@ export class Collection<T extends Resource> extends Resource {
      * @returns an observable of the refreshed resource collection instance
      */
     override read(): Observable<this> {
-        return this._client.get(this.self).pipe(
+        return this.withSelf(self => this._client.get(self).pipe(
             map(obj => new Collection(this.type, {
                 ...obj,
                  _client: this._client
             }) as this),
             catchError(this.handleError)
-        );
+        ));
     }
 }

--- a/src/lib/collection.ts
+++ b/src/lib/collection.ts
@@ -7,7 +7,13 @@ import { Resource } from './resource';
  */
 export class Collection<T extends Resource> extends Resource {
     /**
-     * The elements of the collection.
+     * Zero-based offset of the first element of the `values` array in
+     * the collection.
+     */
+    readonly start: number;
+
+    /**
+     * A page of values of the collection starting with `start` offset.
      */
     readonly values: T[];
 
@@ -15,8 +21,10 @@ export class Collection<T extends Resource> extends Resource {
      * @param type the element resource type
      * @param obj the object used to assign the properties
      */
-    constructor(private readonly type: Type<T>, obj: Object) {
+    constructor(private readonly type: Type<T>, obj: any) {
         super(obj);
+
+        this.start = obj.start > 0 ? Math.trunc(obj.start) : 0;
 
         for (const rel in this._embedded) {
             const values = this._embedded[rel];

--- a/src/lib/collection.ts
+++ b/src/lib/collection.ts
@@ -5,6 +5,8 @@ import { Accessor } from './accessor';
 
 const next = 'next';
 
+const prev = 'prev';
+
 /**
  * This class represents an in-memory collection of resources.
  */
@@ -42,8 +44,24 @@ export class Collection<T extends Resource> extends Resource {
         this.values = [];
     }
 
+    /**
+     * Follow `next` link if it exists and can be read.
+     *
+     * @returns the accessor for the link or `undefined`
+     */
     next(): Accessor | undefined {
         const accessor = this.follow(next);
+
+        return !!accessor && accessor.canRead ? accessor : undefined;
+    }
+
+    /**
+     * Follow `prev` link if it exists and can be read.
+     *
+     * @returns the accessor for the link or `undefined`
+     */
+    previous(): Accessor | undefined {
+        const accessor = this.follow(prev);
 
         return !!accessor && accessor.canRead ? accessor : undefined;
     }

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -52,12 +52,10 @@ export class Resource extends HalBase {
     read(): Observable<this> {
         const type = this.constructor as Type<this>;
 
-        return this.withSelf(
-            self => this._client.get(self).pipe(
-                map(obj => this.instanceOf(type, obj)),
-                catchError(this.handleError)
-            )
-        );
+        return this.withSelf(self => this._client.get(self).pipe(
+            map(obj => this.instanceOf(type, obj)),
+            catchError(this.handleError)
+        ));
     }
 
     /**
@@ -67,12 +65,10 @@ export class Resource extends HalBase {
      * @returns an observable of resource accessor
      */
     update(): Observable<Accessor> {
-        return this.withSelf(
-            self => this._client.put(self, this.sanitize(this)).pipe(
-                map(() => this.accessor(self)),
-                catchError(this.handleError)
-            )
-        );
+        return this.withSelf(self => this._client.put(self, this.sanitize(this)).pipe(
+            map(() => this.accessor(self)),
+            catchError(this.handleError)
+        ));
     }
 
     /**


### PR DESCRIPTION
Implement pagination in `Collection` object: `start` property and `next()` and `previous()` methods. Fix a tiny bug in `read()` method.